### PR TITLE
Fix functional tests for CKAN 2.9.x

### DIFF
--- a/ckanext/spatial/tests/functional/__init__.py
+++ b/ckanext/spatial/tests/functional/__init__.py
@@ -5,3 +5,7 @@ try:
 except ImportError:
     import pkgutil
     __path__ = pkgutil.extend_path(__path__, __name__)
+
+from ckan.plugins import toolkit
+
+legacy_routing = toolkit.check_ckan_version(max_version='2.9')

--- a/ckanext/spatial/tests/functional/test_package.py
+++ b/ckanext/spatial/tests/functional/test_package.py
@@ -14,6 +14,7 @@ except ImportError:
 from ckanext.spatial.model import PackageExtent
 from ckanext.spatial.geoalchemy_common import legacy_geoalchemy
 from ckanext.spatial.tests.base import SpatialTestBase
+from ckanext.spatial.tests.functional import legacy_routing
 
 
 class TestSpatialExtra(SpatialTestBase, helpers.FunctionalTestBase):
@@ -25,7 +26,11 @@ class TestSpatialExtra(SpatialTestBase, helpers.FunctionalTestBase):
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         dataset = factories.Dataset(user=user)
 
-        offset = url_for(controller='package', action='edit', id=dataset['id'])
+        if legacy_routing:
+            offset = url_for(controller='package', action='edit',
+                             id=dataset['id'])
+        else:
+            offset = url_for('dataset.edit', id=dataset['id'])
         res = app.get(offset, extra_environ=env)
 
         form = res.forms[1]
@@ -66,7 +71,11 @@ class TestSpatialExtra(SpatialTestBase, helpers.FunctionalTestBase):
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         dataset = factories.Dataset(user=user)
 
-        offset = url_for(controller='package', action='edit', id=dataset['id'])
+        if legacy_routing:
+            offset = url_for(controller='package', action='edit',
+                             id=dataset['id'])
+        else:
+            offset = url_for('dataset.edit', id=dataset['id'])
         res = app.get(offset, extra_environ=env)
 
         form = res.forms[1]
@@ -113,7 +122,11 @@ class TestSpatialExtra(SpatialTestBase, helpers.FunctionalTestBase):
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         dataset = factories.Dataset(user=user)
 
-        offset = url_for(controller='package', action='edit', id=dataset['id'])
+        if legacy_routing:
+            offset = url_for(controller='package', action='edit',
+                             id=dataset['id'])
+        else:
+            offset = url_for('dataset.edit', id=dataset['id'])
         res = app.get(offset, extra_environ=env)
 
         form = res.forms[1]
@@ -133,7 +146,11 @@ class TestSpatialExtra(SpatialTestBase, helpers.FunctionalTestBase):
         env = {'REMOTE_USER': user['name'].encode('ascii')}
         dataset = factories.Dataset(user=user)
 
-        offset = url_for(controller='package', action='edit', id=dataset['id'])
+        if legacy_routing:
+            offset = url_for(controller='package', action='edit',
+                             id=dataset['id'])
+        else:
+            offset = url_for('dataset.edit', id=dataset['id'])
         res = app.get(offset, extra_environ=env)
 
         form = res.forms[1]

--- a/ckanext/spatial/tests/functional/test_widgets.py
+++ b/ckanext/spatial/tests/functional/test_widgets.py
@@ -1,6 +1,7 @@
 from ckan.lib.helpers import url_for
 
 from ckanext.spatial.tests.base import SpatialTestBase
+from ckanext.spatial.tests.functional import legacy_routing
 
 try:
     import ckan.new_tests.helpers as helpers
@@ -21,7 +22,11 @@ class TestSpatialWidgets(SpatialTestBase, helpers.FunctionalTestBase):
             extras=[{'key': 'spatial',
                      'value': self.geojson_examples['point']}]
         )
-        offset = url_for(controller='package', action='read', id=dataset['id'])
+        if legacy_routing:
+            offset = url_for(controller='package', action='read',
+                             id=dataset['id'])
+        else:
+            offset = url_for('dataset.read', id=dataset['name'])
         res = app.get(offset)
 
         assert 'data-module="dataset-map"' in res
@@ -31,7 +36,10 @@ class TestSpatialWidgets(SpatialTestBase, helpers.FunctionalTestBase):
 
         app = self._get_test_app()
 
-        offset = url_for(controller='package', action='search')
+        if legacy_routing:
+            offset = url_for(controller='package', action='search')
+        else:
+            offset = url_for('dataset.search')
         res = app.get(offset)
 
         assert 'data-module="spatial-query"' in res


### PR DESCRIPTION
CKAN 2.9.x breaks the functional tests because they rely on the legacy Pylons routing rather than the new Flask routing. This PR adds a check for the CKAN version and then uses the appropriate routing in the functional tests. The Travis build against CKAN master will now succeed; the builds against CKAN 2.8 and lower are unaffected.